### PR TITLE
Implement the ability to rename the tables without contriving your type names, and more!

### DIFF
--- a/demo/user.go
+++ b/demo/user.go
@@ -1,14 +1,15 @@
 package demo
 
-//go:generate ../sqlgen -file user.go -type User -pkg demo -o user_sql.go
+//go:generate ../sqlgen -file user.go -type LegacyUser -pkg demo -o user_sql.go
 
-type User struct {
-	ID     int64  `sql:"pk: true, auto: true"`
-	Login  string `sql:"unique: user_login"`
-	Email  string `sql:"unique: user_email"`
-	Avatar string
-	Active bool
-	Admin  bool
+type LegacyUser struct {
+	SQLName string `sql:"name: users, skip: true"`
+	ID      int64  `sql:"pk: true, auto: true"`
+	Login   string `sql:"unique: login"`
+	Email   string `sql:"unique: email"`
+	Avatar  string
+	Active  bool
+	Admin   bool
 
 	// oauth token and secret
 	token  string

--- a/demo/user_sql.go
+++ b/demo/user_sql.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 )
 
-func ScanUser(row *sql.Row) (*User, error) {
+func ScanLegacyUser(row *sql.Row) (*LegacyUser, error) {
 	var v0 int64
 	var v1 string
 	var v2 string
@@ -32,7 +32,7 @@ func ScanUser(row *sql.Row) (*User, error) {
 		return nil, err
 	}
 
-	v := &User{}
+	v := &LegacyUser{}
 	v.ID = v0
 	v.Login = v1
 	v.Email = v2
@@ -46,9 +46,9 @@ func ScanUser(row *sql.Row) (*User, error) {
 	return v, nil
 }
 
-func ScanUsers(rows *sql.Rows) ([]*User, error) {
+func ScanLegacyUsers(rows *sql.Rows) ([]*LegacyUser, error) {
 	var err error
-	var vv []*User
+	var vv []*LegacyUser
 
 	var v0 int64
 	var v1 string
@@ -76,7 +76,7 @@ func ScanUsers(rows *sql.Rows) ([]*User, error) {
 			return vv, err
 		}
 
-		v := &User{}
+		v := &LegacyUser{}
 		v.ID = v0
 		v.Login = v1
 		v.Email = v2
@@ -92,7 +92,7 @@ func ScanUsers(rows *sql.Rows) ([]*User, error) {
 	return vv, rows.Err()
 }
 
-func SliceUser(v *User) []interface{} {
+func SliceLegacyUser(v *LegacyUser) []interface{} {
 	var v0 int64
 	var v1 string
 	var v2 string
@@ -126,23 +126,23 @@ func SliceUser(v *User) []interface{} {
 	}
 }
 
-func SelectUser(db *sql.DB, query string, args ...interface{}) (*User, error) {
+func SelectLegacyUser(db *sql.DB, query string, args ...interface{}) (*LegacyUser, error) {
 	row := db.QueryRow(query, args...)
-	return ScanUser(row)
+	return ScanLegacyUser(row)
 }
 
-func SelectUsers(db *sql.DB, query string, args ...interface{}) ([]*User, error) {
+func SelectLegacyUsers(db *sql.DB, query string, args ...interface{}) ([]*LegacyUser, error) {
 	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	return ScanUsers(rows)
+	return ScanLegacyUsers(rows)
 }
 
-func InsertUser(db *sql.DB, query string, v *User) error {
+func InsertLegacyUser(db *sql.DB, query string, v *LegacyUser) error {
 
-	res, err := db.Exec(query, SliceUser(v)[1:]...)
+	res, err := db.Exec(query, SliceLegacyUser(v)[1:]...)
 	if err != nil {
 		return err
 	}
@@ -151,9 +151,9 @@ func InsertUser(db *sql.DB, query string, v *User) error {
 	return err
 }
 
-func UpdateUser(db *sql.DB, query string, v *User) error {
+func UpdateLegacyUser(db *sql.DB, query string, v *LegacyUser) error {
 
-	args := SliceUser(v)[1:]
+	args := SliceLegacyUser(v)[1:]
 	args = append(args, v.ID)
 	_, err := db.Exec(query, args...)
 	return err
@@ -161,56 +161,56 @@ func UpdateUser(db *sql.DB, query string, v *User) error {
 
 const CreateUserStmt = `
 CREATE TABLE IF NOT EXISTS users (
- user_id     INTEGER PRIMARY KEY AUTOINCREMENT
-,user_login  TEXT
-,user_email  TEXT
-,user_avatar TEXT
-,user_active BOOLEAN
-,user_admin  BOOLEAN
-,user_token  TEXT
-,user_secret TEXT
-,user_hash   TEXT
+ id     INTEGER PRIMARY KEY AUTOINCREMENT
+,login  TEXT
+,email  TEXT
+,avatar TEXT
+,active BOOLEAN
+,admin  BOOLEAN
+,token  TEXT
+,secret TEXT
+,hash   TEXT
 );
 `
 
 const InsertUserStmt = `
 INSERT INTO users (
- user_login
-,user_email
-,user_avatar
-,user_active
-,user_admin
-,user_token
-,user_secret
-,user_hash
+ login
+,email
+,avatar
+,active
+,admin
+,token
+,secret
+,hash
 ) VALUES (?,?,?,?,?,?,?,?)
 `
 
 const SelectUserStmt = `
 SELECT 
- user_id
-,user_login
-,user_email
-,user_avatar
-,user_active
-,user_admin
-,user_token
-,user_secret
-,user_hash
+ id
+,login
+,email
+,avatar
+,active
+,admin
+,token
+,secret
+,hash
 FROM users 
 `
 
 const SelectUserRangeStmt = `
 SELECT 
- user_id
-,user_login
-,user_email
-,user_avatar
-,user_active
-,user_admin
-,user_token
-,user_secret
-,user_hash
+ id
+,login
+,email
+,avatar
+,active
+,admin
+,token
+,secret
+,hash
 FROM users 
 LIMIT ? OFFSET ?
 `
@@ -222,110 +222,110 @@ FROM users
 
 const SelectUserPkeyStmt = `
 SELECT 
- user_id
-,user_login
-,user_email
-,user_avatar
-,user_active
-,user_admin
-,user_token
-,user_secret
-,user_hash
+ id
+,login
+,email
+,avatar
+,active
+,admin
+,token
+,secret
+,hash
 FROM users 
-WHERE user_id=?
+WHERE id=?
 `
 
 const UpdateUserPkeyStmt = `
 UPDATE users SET 
- user_id=?
-,user_login=?
-,user_email=?
-,user_avatar=?
-,user_active=?
-,user_admin=?
-,user_token=?
-,user_secret=?
-,user_hash=? 
-WHERE user_id=?
+ id=?
+,login=?
+,email=?
+,avatar=?
+,active=?
+,admin=?
+,token=?
+,secret=?
+,hash=? 
+WHERE id=?
 `
 
 const DeleteUserPkeyStmt = `
 DELETE FROM users 
-WHERE user_id=?
+WHERE id=?
 `
 
-const CreateUserLoginStmt = `
-CREATE UNIQUE INDEX IF NOT EXISTS user_login ON users (user_login)
+const CreateLoginStmt = `
+CREATE UNIQUE INDEX IF NOT EXISTS login ON users (login)
 `
 
-const SelectUserLoginStmt = `
+const SelectLoginStmt = `
 SELECT 
- user_id
-,user_login
-,user_email
-,user_avatar
-,user_active
-,user_admin
-,user_token
-,user_secret
-,user_hash
+ id
+,login
+,email
+,avatar
+,active
+,admin
+,token
+,secret
+,hash
 FROM users 
-WHERE user_login=?
+WHERE login=?
 `
 
-const UpdateUserLoginStmt = `
+const UpdateLoginStmt = `
 UPDATE users SET 
- user_id=?
-,user_login=?
-,user_email=?
-,user_avatar=?
-,user_active=?
-,user_admin=?
-,user_token=?
-,user_secret=?
-,user_hash=? 
-WHERE user_login=?
+ id=?
+,login=?
+,email=?
+,avatar=?
+,active=?
+,admin=?
+,token=?
+,secret=?
+,hash=? 
+WHERE login=?
 `
 
-const DeleteUserLoginStmt = `
+const DeleteLoginStmt = `
 DELETE FROM users 
-WHERE user_login=?
+WHERE login=?
 `
 
-const CreateUserEmailStmt = `
-CREATE UNIQUE INDEX IF NOT EXISTS user_email ON users (user_email)
+const CreateEmailStmt = `
+CREATE UNIQUE INDEX IF NOT EXISTS email ON users (email)
 `
 
-const SelectUserEmailStmt = `
+const SelectEmailStmt = `
 SELECT 
- user_id
-,user_login
-,user_email
-,user_avatar
-,user_active
-,user_admin
-,user_token
-,user_secret
-,user_hash
+ id
+,login
+,email
+,avatar
+,active
+,admin
+,token
+,secret
+,hash
 FROM users 
-WHERE user_email=?
+WHERE email=?
 `
 
-const UpdateUserEmailStmt = `
+const UpdateEmailStmt = `
 UPDATE users SET 
- user_id=?
-,user_login=?
-,user_email=?
-,user_avatar=?
-,user_active=?
-,user_admin=?
-,user_token=?
-,user_secret=?
-,user_hash=? 
-WHERE user_email=?
+ id=?
+,login=?
+,email=?
+,avatar=?
+,active=?
+,admin=?
+,token=?
+,secret=?
+,hash=? 
+WHERE email=?
 `
 
-const DeleteUserEmailStmt = `
+const DeleteEmailStmt = `
 DELETE FROM users 
-WHERE user_email=?
+WHERE email=?
 `

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -56,8 +56,23 @@ func buildNodes(parent *Node, spec *ast.TypeSpec) error {
 		if field.Tag != nil {
 			tag = field.Tag.Value
 		}
-		buildNode(parent, field.Type, field.Names[0].Name, tag)
+
+		if field.Names[0].Name == "SQLName" {
+			var err error
+
+			parent.Tags, err = parseTag(tag)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		if err := buildNode(parent, field.Type, field.Names[0].Name, tag); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 

--- a/schema/helper.go
+++ b/schema/helper.go
@@ -3,8 +3,8 @@ package schema
 import (
 	"strings"
 
-	"github.com/drone/sqlgen/parse"
 	"github.com/acsellers/inflections"
+	"github.com/drone/sqlgen/parse"
 )
 
 func Load(tree *parse.Node) *Table {
@@ -16,8 +16,12 @@ func Load(tree *parse.Node) *Table {
 
 	// pluralizes the table name and then
 	// formats in snake case.
-	table.Name = inflections.Underscore(tree.Type)
-	table.Name = inflections.Pluralize(table.Name)
+	if tree.Tags != nil && tree.Tags.Name != "" {
+		table.Name = tree.Tags.Name
+	} else {
+		table.Name = inflections.Underscore(tree.Type)
+		table.Name = inflections.Pluralize(table.Name)
+	}
 
 	// each edge node in the tree is a column
 	// in the table. Convert each edge node to
@@ -81,6 +85,10 @@ func Load(tree *parse.Node) *Table {
 		path := node.Path()
 		var parts []string
 		for _, part := range path {
+			if part.Tags != nil && part.Tags.Skip {
+				continue
+			}
+
 			if part.Tags != nil && part.Tags.Name != "" {
 				parts = append(parts, part.Tags.Name)
 				continue
@@ -88,6 +96,7 @@ func Load(tree *parse.Node) *Table {
 
 			parts = append(parts, part.Name)
 		}
+
 		field.Name = strings.Join(parts, "_")
 		field.Name = inflections.Underscore(field.Name)
 


### PR DESCRIPTION
This short-circuits the type parsing so that when it hits an element named "SQLName" it will automatically tack the tags parsed for that onto the parent type. This allows us to apply tags to the struct.

Additionally, this implements the following behaviour on the schema gen:
-  if `skip: true` is in the tag, it will skip that field for name concatation. ( To allow fully-naming the fields of a column in the struct.)

An example / test case of this has been retrofitted into the [demo/users.go]() file.
