### PR TITLE
Adds CRUD methods based on new flags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ sqlgen
 *.sqlite
 *.txt
 _docs
+vendor/**
+!vendor/manifest

--- a/gen.go
+++ b/gen.go
@@ -20,6 +20,8 @@ var (
 	genSchema  = flag.Bool("schema", true, "generate sql schema and queries")
 	genFuncs   = flag.Bool("funcs", true, "generate sql helper functions")
 	extraFuncs = flag.Bool("extras", true, "generate extra sql helper functions")
+	doDI       = flag.Bool("doDI", false, "generate an interface for DI")
+	diName     = flag.String("diName", "sql.DB", "the concrete class to attach methods to")
 )
 
 func main() {
@@ -53,10 +55,13 @@ func main() {
 		writeSliceFunc(&buf, tree)
 
 		if *extraFuncs {
-			writeSelectRow(&buf, tree)
-			writeSelectRows(&buf, tree)
-			writeInsertFunc(&buf, tree)
-			writeUpdateFunc(&buf, tree)
+			writeSelectRow(&buf, tree, *doDI, *diName)
+			writeSelectRows(&buf, tree, *doDI, *diName)
+			writeInsertFunc(&buf, tree, *doDI, *diName)
+			writeUpdateFunc(&buf, tree, *doDI, *diName)
+		}
+		if *doDI {
+			writeInterface(&buf, tree)
 		}
 	} else {
 		writePackage(&buf, *pkgName)

--- a/gen_funcs.go
+++ b/gen_funcs.go
@@ -228,23 +228,43 @@ func writeRowsFunc(w io.Writer, tree *parse.Node) {
 	)
 }
 
-func writeSelectRow(w io.Writer, tree *parse.Node) {
-	fmt.Fprintf(w, sSelectRow, tree.Type, tree.Type, tree.Type)
+func writeSelectRow(w io.Writer, tree *parse.Node, doDI bool, diName string) {
+	if doDI {
+		fmt.Fprintf(w, sSelectRowDI, diName, tree.Type, tree.Type, tree.Type)
+	} else {
+		fmt.Fprintf(w, sSelectRow, tree.Type, tree.Type, tree.Type)
+	}
 }
 
-func writeSelectRows(w io.Writer, tree *parse.Node) {
+func writeSelectRows(w io.Writer, tree *parse.Node, doDI bool, diName string) {
 	plural := inflections.Pluralize(tree.Type)
-	fmt.Fprintf(w, sSelectRows, plural, tree.Type, plural)
+	if doDI {
+		fmt.Fprintf(w, sSelectRowsDI, diName, plural, tree.Type, plural)
+	} else {
+		fmt.Fprintf(w, sSelectRows, plural, tree.Type, plural)
+	}
 }
 
-func writeInsertFunc(w io.Writer, tree *parse.Node) {
+func writeInsertFunc(w io.Writer, tree *parse.Node, doDI bool, diName string) {
 	// TODO this assumes I'm using the ID field.
 	// we should not make that assumption
-	fmt.Fprintf(w, sInsert, tree.Type, tree.Type, tree.Type)
+	if doDI {
+		fmt.Fprintf(w, sInsertDI, diName, tree.Type, tree.Type, tree.Type)
+	} else {
+		fmt.Fprintf(w, sInsert, tree.Type, tree.Type, tree.Type)
+	}
 }
 
-func writeUpdateFunc(w io.Writer, tree *parse.Node) {
-	fmt.Fprintf(w, sUpdate, tree.Type, tree.Type, tree.Type)
+func writeUpdateFunc(w io.Writer, tree *parse.Node, doDI bool, diName string) {
+	if doDI {
+		fmt.Fprintf(w, sUpdateDI, diName, tree.Type, tree.Type, tree.Type)
+	} else {
+		fmt.Fprintf(w, sUpdate, tree.Type, tree.Type, tree.Type)
+	}
+}
+
+func writeInterface(w io.Writer, tree *parse.Node) {
+	fmt.Fprintf(w, sInterface, tree.Type)
 }
 
 // join is a helper function that joins nodes

--- a/tmpl.go
+++ b/tmpl.go
@@ -82,9 +82,26 @@ func Select%s(db *sql.DB, query string, args ...interface{}) (*%s, error) {
 }
 `
 
+const sSelectRowDI = `
+func (db *%s) Select%s(query string, args ...interface{}) (*%s, error) {
+	row := db.QueryRow(query, args...)
+	return Scan%s(row)
+}
+`
+
 // function template to select multiple rows.
 const sSelectRows = `
 func Select%s(db *sql.DB, query string, args ...interface{}) ([]*%s, error) {
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return Scan%s(rows)
+}
+`
+const sSelectRowsDI = `
+func (db *%s) Select%s(query string, args ...interface{}) ([]*%s, error) {
 	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil, err
@@ -107,6 +124,18 @@ func Insert%s(db *sql.DB, query string, v *%s) error {
 	return err
 }
 `
+const sInsertDI = `
+func (db *%s) Insert%s(query string, v *%s) error {
+
+	res, err := db.Exec(query, Slice%s(v)[1:]...)
+	if err != nil {
+		return err
+	}
+
+	v.ID, err = res.LastInsertId()
+	return err
+}
+`
 
 // function template to update a single row.
 const sUpdate = `
@@ -116,5 +145,23 @@ func Update%s(db *sql.DB, query string, v *%s) error {
 	args = append(args, v.ID)
 	_, err := db.Exec(query, args...)
 	return err 
+}
+`
+const sUpdateDI = `
+func (db *%s) Update%s(query string, v *%s) error {
+
+	args := Slice%s(v)[1:]
+	args = append(args, v.ID)
+	_, err := db.Exec(query, args...)
+	return err
+}
+`
+
+const sInterface = `
+type %sStore interface {
+	Select%s(string, ...interface{}) (*%s, error)
+	Select%s(string, ...interface{}) ([]*%s, error)
+	Insert%s(string, *%s) error
+	Update%s(string, *%s) error
 }
 `

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1,0 +1,41 @@
+{
+	"version": 0,
+	"dependencies": [
+		{
+			"importpath": "bitbucket.org/pkg/inflect",
+			"repository": "https://bitbucket.org/pkg/inflect",
+			"revision": "8961c3750a47",
+			"branch": "default"
+		},
+		{
+			"importpath": "github.com/acsellers/inflections",
+			"repository": "https://github.com/acsellers/inflections",
+			"revision": "cb98bfe9e3ee28e8649778f5fbb2e95f54f71b39",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/jmoiron/sqlx",
+			"repository": "https://github.com/jmoiron/sqlx",
+			"revision": "54aec3fd91a2b2129ffaca0d652b8a9223ee2d9e",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/mattn/go-sqlite3",
+			"repository": "https://github.com/mattn/go-sqlite3",
+			"revision": "5651a9d9d49ec25811d08220ee972080378d52ea",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/russross/meddler",
+			"repository": "https://github.com/russross/meddler",
+			"revision": "f742b0f9424f3bfaffe189e921d734608929e84f",
+			"branch": "master"
+		},
+		{
+			"importpath": "gopkg.in/yaml.v2",
+			"repository": "https://gopkg.in/yaml.v2",
+			"revision": "53feefa2559fb8dfa8d81baad31be332c97d6c77",
+			"branch": "v2"
+		}
+	]
+}


### PR DESCRIPTION
I wanted to generate the CRUD functions as methods on a type. This allows me to define a CRUD interface in my application. That then allows me to inject the interface as a dependency into my handlers. This allows me to mock the interface easily when testing those handler functions.

The mechanism is the addition of two flags.
- `doDI` adds a receiver to the CRUD functions
- `diName` defaults to `*sql.DB` and is the name of the receiver.
