### PR TITLE
Postgres typo

### DIFF
--- a/schema/dialect.go
+++ b/schema/dialect.go
@@ -31,8 +31,8 @@ func New(dialect int) Dialect {
 	case POSTGRES:
 		return newPostgres()
 	case MYSQL:
-		return newMysql()
+		return newMySQL()
 	default:
-		return newSqlite()
+		return newSQLite()
 	}
 }

--- a/schema/dialect.go
+++ b/schema/dialect.go
@@ -29,7 +29,7 @@ type Dialect interface {
 func New(dialect int) Dialect {
 	switch dialect {
 	case POSTGRES:
-		return newPosgres()
+		return newPostgres()
 	case MYSQL:
 		return newMysql()
 	default:

--- a/schema/dialect_mysql.go
+++ b/schema/dialect_mysql.go
@@ -8,7 +8,7 @@ type mysql struct {
 	base
 }
 
-func newMysql() Dialect {
+func newMySQL() Dialect {
 	d := &mysql{}
 	d.base.Dialect = d
 	return d

--- a/schema/dialect_postgres.go
+++ b/schema/dialect_postgres.go
@@ -4,18 +4,18 @@ import (
 	"fmt"
 )
 
-type posgres struct {
+type postgres struct {
 	base
 }
 
-func newPosgres() Dialect {
-	d := &posgres{}
+func newPostgres() Dialect {
+	d := &postgres{}
 	d.base.Dialect = d
 	return d
 }
 
-func (d *posgres) Column(f *Field) (_ string) {
-	// posgres uses a special column type
+func (d *postgres) Column(f *Field) (_ string) {
+	// postgres uses a special column type
 	// to autoincrementing keys.
 	if f.Auto {
 		return "SERIAL"
@@ -41,7 +41,7 @@ func (d *posgres) Column(f *Field) (_ string) {
 	}
 }
 
-func (d *posgres) Token(v int) (_ string) {
+func (d *postgres) Token(v int) (_ string) {
 	switch v {
 	case AUTO_INCREMENT:
 		// postgres does not support the
@@ -54,6 +54,6 @@ func (d *posgres) Token(v int) (_ string) {
 	}
 }
 
-func (d *posgres) Param(i int) string {
+func (d *postgres) Param(i int) string {
 	return fmt.Sprintf("$%d", i+1)
 }

--- a/schema/dialect_sqlite.go
+++ b/schema/dialect_sqlite.go
@@ -4,7 +4,7 @@ type sqlite struct {
 	base
 }
 
-func newSqlite() Dialect {
+func newSQLite() Dialect {
 	d := &sqlite{}
 	d.base.Dialect = d
 	return d


### PR DESCRIPTION
renames symbols for SQL dialect names:

posgres --> postgres
newPosgres --> newPostgres
newMysql --> newMySQL
newSqlite --> newSQLite
