### PR TITLE
set primary key, continued

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -55,7 +55,7 @@ func main() {
 		if *extraFuncs {
 			writeSelectRow(&buf, tree)
 			writeSelectRows(&buf, tree)
-			writeInsertFunc(&buf, tree)
+			writeInsertFunc(&buf, tree, table)
 			writeUpdateFunc(&buf, tree)
 		}
 	} else {

--- a/gen_funcs.go
+++ b/gen_funcs.go
@@ -239,13 +239,11 @@ func writeSelectRows(w io.Writer, tree *parse.Node) {
 }
 
 func writeInsertFunc(w io.Writer, tree *parse.Node, table *schema.Table) {
-	var hook string
 	if table.LastInsertId {
-		hook = sLastInsertId
+		fmt.Fprintf(w, sInsertAndGetLastId, tree.Type, tree.Type, tree.Type)
 	} else {
-		hook = sNoLastInsertId
+		fmt.Fprintf(w, sInsert, tree.Type, tree.Type, tree.Type)
 	}
-	fmt.Fprintf(w, sInsert, tree.Type, tree.Type, tree.Type, hook)
 }
 
 func writeUpdateFunc(w io.Writer, tree *parse.Node) {

--- a/gen_funcs.go
+++ b/gen_funcs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/acsellers/inflections"
 	"github.com/drone/sqlgen/parse"
+	"github.com/drone/sqlgen/schema"
 )
 
 func writeImports(w io.Writer, tree *parse.Node, pkgs ...string) {
@@ -237,10 +238,14 @@ func writeSelectRows(w io.Writer, tree *parse.Node) {
 	fmt.Fprintf(w, sSelectRows, plural, tree.Type, plural)
 }
 
-func writeInsertFunc(w io.Writer, tree *parse.Node) {
-	// TODO this assumes I'm using the ID field.
-	// we should not make that assumption
-	fmt.Fprintf(w, sInsert, tree.Type, tree.Type, tree.Type)
+func writeInsertFunc(w io.Writer, tree *parse.Node, table *schema.Table) {
+	var hook string
+	if table.LastInsertId {
+		hook = sLastInsertId
+	} else {
+		hook = sNoLastInsertId
+	}
+	fmt.Fprintf(w, sInsert, tree.Type, tree.Type, tree.Type, hook)
 }
 
 func writeUpdateFunc(w io.Writer, tree *parse.Node) {

--- a/schema/helper.go
+++ b/schema/helper.go
@@ -51,6 +51,7 @@ func Load(tree *parse.Node) *Table {
 			if node.Name == "ID" && node.Kind == parse.Int64 {
 				node.Tags.Primary = true
 				node.Tags.Auto = true
+				table.LastInsertId = true
 			}
 
 			field.Auto = node.Tags.Auto

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -16,7 +16,8 @@ const (
 )
 
 type Table struct {
-	Name string
+	Name         string
+	LastInsertId bool
 
 	Fields  []*Field
 	Index   []*Index

--- a/tmpl.go
+++ b/tmpl.go
@@ -103,9 +103,17 @@ func Insert%s(db *sql.DB, query string, v *%s) error {
 		return err
 	}
 
-	v.ID, err = res.LastInsertId()
+	%s
 	return err
 }
+`
+
+const sLastInsertId = `
+	v.ID, err = res.LastInsertId()
+`
+
+const sNoLastInsertId = `
+	_ = res
 `
 
 // function template to update a single row.

--- a/tmpl.go
+++ b/tmpl.go
@@ -95,25 +95,23 @@ func Select%s(db *sql.DB, query string, args ...interface{}) ([]*%s, error) {
 `
 
 // function template to insert a single row.
-const sInsert = `
+const sInsertAndGetLastId = `
 func Insert%s(db *sql.DB, query string, v *%s) error {
-
 	res, err := db.Exec(query, Slice%s(v)[1:]...)
 	if err != nil {
 		return err
 	}
 
-	%s
+	v.ID, err = res.LastInsertId()
 	return err
 }
 `
 
-const sLastInsertId = `
-	v.ID, err = res.LastInsertId()
-`
-
-const sNoLastInsertId = `
-	_ = res
+const sInsert = `
+func Insert%s(db *sql.DB, query string, v *%s) error {
+	_, err := db.Exec(query, Slice%s(v)...)
+	return err
+}
 `
 
 // function template to update a single row.


### PR DESCRIPTION
the code

```
v.ID, err = res.LastInsertId()
```

will fail with string ID fields.  This PR includes that block of code if and only if ID is int64.

Alternatively `func Insert%s()` could return res.LastInsertID() and give the client a choice to use it.
